### PR TITLE
Add rake to dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/*
 .bundle
+/pkg/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     jmespath (1.4.0)
     minitest (5.12.2)
     pathspec (0.2.1)
+    rake (13.0.0)
     rubyzip (1.3.0)
     subprocess (1.3.2)
     thread_safe (0.3.6)
@@ -70,6 +71,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug (~> 9)
+  rake (~> 13.0)
   rebi!
 
 BUNDLED WITH

--- a/rebi.gemspec
+++ b/rebi.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
   s.add_dependency "subprocess", "~> 1.3"
   s.add_dependency "pathspec", "~> 0.2"
 
+  s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "byebug", "~> 9"
 end


### PR DESCRIPTION
it's useful.
```shell
$ bundle exec rake --tasks
rake build            # Build rebi-0.4.2.gem into the pkg directory
rake clean            # Remove any temporary products
rake clobber          # Remove any generated files
rake clobber_rdoc     # Remove RDoc HTML files
rake install          # Build and install rebi-0.4.2.gem into system gems
rake install:local    # Build and install rebi-0.4.2.gem into system gems without network access
rake rdoc             # Build RDoc HTML files
rake release[remote]  # Create tag v0.4.2 and build and push rebi-0.4.2.gem to rubygems.org
rake rerdoc           # Rebuild RDoc HTML files
rake test             # Run tests
```